### PR TITLE
expand canvas to account for drop shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ progress.options.text = {
 
 Update percent and draw the canvas, `value` must be a float between 0 and 100.
 
+### shadowBlur
+
+If you would like to add a drop shadow to the progress bar to create a "glow" effect you can.  This will expand the size of the canvas from the diameter of the progress par to include the size of the drop shadow.  In the below example, the canvas ends up 96px wide and tall.
+
+![circleprogress_with_shadow](https://cloud.githubusercontent.com/assets/895892/4994836/d4cfc4dc-6979-11e4-9ecc-d9cdd01e8526.png)
+
+```
+var progress = new CircularProgress({
+      radius: 42,
+      strokeStyle: '#FFFFFF',
+      shadowColor: '#00d1ff',
+      shadowBlur: 12,
+      lineCap: 'round',
+      lineWidth: 4
+    });
+```
+
 ## License
 
 MIT

--- a/circular-progress.js
+++ b/circular-progress.js
@@ -65,8 +65,8 @@
   // Specify a new `radius` for the circle
   CircularProgress.prototype.radius = function (value) {
     var size = value * 2;
-    this.el.width = size;
-    this.el.height = size;
+    this.el.width = size + this.options.shadowBlur + Math.abs(this.options.shadowOffsetX);
+    this.el.height = size + this.options.shadowBlur + Math.abs(this.options.shadowOffsetY);
     autoscale(this.el);
     return this;
   };
@@ -79,12 +79,14 @@
         percent = Math.min(this._percent, 100),
         ratio = window.devicePixelRatio || 1,
         angle = Math.PI * 2 * percent / 100,
-        size = this.el.width / ratio,
-        half = size / 2,
-        x = half,
-        y = half;
+        width = this.el.width / ratio,
+        height = this.el.height / ratio,
+        x = width / 2,
+        y = height / 2,
+        half = ( width - this.options.shadowBlur - Math.abs(this.options.shadowOffsetX)) / 2;
 
-    ctx.clearRect(0, 0, size, size);
+
+      ctx.clearRect(0, 0, width, height);
 
     // Initial circle
     if (options.initial) {


### PR DESCRIPTION
When I went to implement a "glow" for my circular progress bar I noticed that the drop shadow was getting clipped at both the top and bottom as well as the left and right extremes of the bar which was a less than ideal situation.  This patch expands the canvas to support the full width of the drop shadow.
